### PR TITLE
Get rid of java7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,11 @@ cache:
 language: java
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 env:
   global:
-    - SKIP_JDK8_MODULES='-pl !org.pacesys.openstack4j.connectors:openstack4j-http-connector,!org.pacesys.openstack4j.connectors:openstack4j-jersey2,!org.pacesys:it-jersey2'
-    - DEPLOY=0
-
-matrix:
-  include:
-    - jdk: "oraclejdk8"
-      env:
-        - SKIP_JDK8_MODULES=""
-        - DEPLOY=1
+    - DEPLOY=1
 
 notifications:
   email: false
@@ -27,7 +19,7 @@ notifications:
 install: /bin/true
 
 # When run on JDK7, modules that require JDK8 needs to be skipped
-script: mvn clean verify -B $SKIP_JDK8_MODULES
+script: mvn clean verify -B
 
 after_success:
   - "[[ $DEPLOY == 1 && $TRAVIS_BRANCH == \"master\" ]] && { mvn deploy --settings distribution/settings.xml -DskipTests=true -B; };"

--- a/connectors/http-connector/pom.xml
+++ b/connectors/http-connector/pom.xml
@@ -43,18 +43,6 @@
 					</instructions>
 				</configuration>
 			</plugin>
-
-			<!-- JDK 1.8 required by this connector (https://github.com/ContainX/openstack4j/issues/673) -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/connectors/jersey2/pom.xml
+++ b/connectors/jersey2/pom.xml
@@ -64,18 +64,6 @@
 					</instructions>
 				</configuration>
 			</plugin>
-
-			<!-- JDK 1.8 required by this connector (https://github.com/ContainX/openstack4j/issues/673) -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<encoding>UTF-8</encoding>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Since openstack4j 3.2.0, it is documented only java 8+ is supported. Removing java 7 build and source/target level.